### PR TITLE
Fixed help URL from mtuner.net to github.io

### DIFF
--- a/src/mtuner.cpp
+++ b/src/mtuner.cpp
@@ -342,7 +342,7 @@ void MTuner::saveCaptureWindowLayout()
 
 void MTuner::readDocumentation()
 {
-	QDesktopServices::openUrl(QUrl("http://www.mtuner.net/documentation.html", QUrl::TolerantMode));
+	QDesktopServices::openUrl(QUrl("https://milostosic.github.io/MTuner/", QUrl::TolerantMode));
 }
 
 void MTuner::about()


### PR DESCRIPTION
The old URL http://www.mtuner.net/documentation.html leads to a 404 error.