### PR TITLE
Fix out-of-bound access when filtering reads past the last operation

### DIFF
--- a/src/loader/capture.cpp
+++ b/src/loader/capture.cpp
@@ -1571,6 +1571,11 @@ void Capture::calculateFilteredData()
 	uint32_t maxTimedIdx;
 	const uint32_t minTimeOpIndex = getIndexBefore(m_filter.m_minTimeSnapshot,minTimedIdx);
 	const uint32_t maxTimeOpIndex = getIndexBefore(m_filter.m_maxTimeSnapshot,maxTimedIdx) + 1;
+
+	if (maxTimeOpIndex >= m_operations.size())
+	{
+		maxTimeOpIndex = m_operations.size() - 1;
+	}
 	
 	m_filter.m_operations.clear();
 	m_filter.m_operations.reserve(maxTimeOpIndex - minTimeOpIndex);

--- a/src/loader/capture.cpp
+++ b/src/loader/capture.cpp
@@ -1570,11 +1570,11 @@ void Capture::calculateFilteredData()
 	uint32_t minTimedIdx;
 	uint32_t maxTimedIdx;
 	const uint32_t minTimeOpIndex = getIndexBefore(m_filter.m_minTimeSnapshot,minTimedIdx);
-	const uint32_t maxTimeOpIndex = getIndexBefore(m_filter.m_maxTimeSnapshot,maxTimedIdx) + 1;
+	uint32_t maxTimeOpIndex = getIndexBefore(m_filter.m_maxTimeSnapshot,maxTimedIdx) + 1;
 
 	if (maxTimeOpIndex >= m_operations.size())
 	{
-		maxTimeOpIndex = m_operations.size() - 1;
+		maxTimeOpIndex = (uint32_t) m_operations.size() - 1;
 	}
 	
 	m_filter.m_operations.clear();


### PR DESCRIPTION
An out-of-bound access can occur on the `m_operations` vector when the following conditions are met:
 - the current selection includes the end of the capture
 - filtering is enabled

In that case, `maxTimeOpIndex` will be equal to the number of elements in the `m_operations` vector. Since the loop on line 1593 has a `i<=maxTimeOpIndex` end condition, it is possible to access the `m_operations` vector past its end and to read a non-existent `MemoryOperation`.