### PR TITLE
Fix crash when right-clicking on an empty row in the operations view

### DIFF
--- a/src/bigtable.cpp
+++ b/src/bigtable.cpp
@@ -306,6 +306,9 @@ void BigTable::rowSelected(QTableWidgetItem* _item)
 
 void BigTable::rowRightClick(QTableWidgetItem* _item, const QPoint& _pos)
 {
+	if (_item == NULL)
+		return;
+	
 	m_selectedRows = _item->row() + m_firstVisible;
 	void* item = NULL;
 	m_source->getItem(m_selectedRows,&item);


### PR DESCRIPTION
A crash happens when the big table widget (Operations view or Groups view) is not entirely covered by rows. 

When the number of rows is too low, there is some empty vertical space after the last filled row. Right-clicking on the empty space causes the `BigTable::rowRightClick()` slot to be called. In this function, the `_item` argument is dereferenced, which causes a crash when it's `NULL`.

To repro this, open a capture, zoom in super close on an event, select a range which only encompasses this event (or a very small number of events), open the Operations view, enable filtering, right-click on the empty bottom of the list => crash.

There might be a way to disable the right-click / context menu when the click is done on empty space, but I'm not familiar enough with Qt to find a better fix...