### PR TITLE
Fix tag filtering

### DIFF
--- a/src/loader/capture.cpp
+++ b/src/loader/capture.cpp
@@ -648,11 +648,11 @@ Capture::LoadResult Capture::loadBin(const char* _path)
 					}
 
 					// fill the rest of mem op struct
-					op->m_stackTrace		= st;
-					op->m_chainPrev			= NULL;
-					op->m_chainNext			= NULL;
-					op->m_tag			= tag;
-					op->m_isValid			= 1;
+					op->m_stackTrace = st;
+					op->m_chainPrev  = NULL;
+					op->m_chainNext  = NULL;
+					op->m_tag        = tag;
+					op->m_isValid    = 1;
 
 					m_operations.push_back(op);
 

--- a/src/loader/capture.cpp
+++ b/src/loader/capture.cpp
@@ -651,7 +651,7 @@ Capture::LoadResult Capture::loadBin(const char* _path)
 					op->m_stackTrace		= st;
 					op->m_chainPrev			= NULL;
 					op->m_chainNext			= NULL;
-					op->m_tag				= (uint16_t)(tag & 0xffff);
+					op->m_tag			= tag;
 					op->m_isValid			= 1;
 
 					m_operations.push_back(op);

--- a/src/loader/mtunerlib.h
+++ b/src/loader/mtunerlib.h
@@ -42,7 +42,7 @@ struct MemoryOperation
 	uint32_t			m_indexMapping;
 	uint32_t			m_allocSize;
 	uint32_t			m_overhead;
-	uint16_t			m_tag;
+	uint32_t			m_tag;
 	uint8_t				m_operationType : 7;
 	uint8_t				m_isValid		: 1;
 	uint8_t				m_alignment;


### PR DESCRIPTION
Tag filtering is broken.

In the tag tree, tag hashes are stored as `uint32_t`'s, but during capture loading (`Capture::loadBin()`), only the low 16 bits of the tag are stored in each `MemoryOperation`. Tag filtering is performed on the full 32-bit value in `Capture::isInFilter()`, and unless the first two MSBs of the tag are 0, it will fail.

To fix this I extended the `tag` field in `MemoryOperation` to a full `uint32_t`. This will increase the size of each `MemoryOperation` by 2 extra bytes, so I don't know if that's the fix you'll prefer. Another fix would be to modify the tag test in `isInFilter()` to only test the low 16 bits, at the cost of an increased false positive risk. Feel free to implement the fix you like best :)

Cheers!