### PR TITLE
Fix comparison of loadBin result to LoadResult enum

### DIFF
--- a/src/mtunermain.cpp
+++ b/src/mtunermain.cpp
@@ -307,7 +307,7 @@ int handleCommandLine(int argc, char const* argv[])
 	{
 		CaptureContext context;
 
-		if (context.m_capture->loadBin(inFilePath))
+		if (context.m_capture->loadBin(inFilePath) == rtm::Capture::LoadResult::LoadSuccess)
 		{
 			setupLoaderToolchain(&context, inFilePath, &gcc_setup, NULL, NULL,  symSource ? QString(symSource) : QString(""));
 


### PR DESCRIPTION
This commit should fix #81 . 
The problem was that loading the file worked totally fine, but the `LoadResult` enum has `LoadSuccess` listed as its first item, therefore it's 0. Hence, the corresponding if case would result in false in a working case and in true although `loadBin` returns a failure. With this fix log file creation is successful.